### PR TITLE
Added memory library to openssl_curve_wrapper.cpp

### DIFF
--- a/src/crypto-suites/crypto-curve/openssl_curve_wrapper.cpp
+++ b/src/crypto-suites/crypto-curve/openssl_curve_wrapper.cpp
@@ -1,6 +1,7 @@
 #include <cassert>
 #include <openssl/ec.h>
 #include <cstring>
+#include <memory>
 #include "crypto-suites/common/ByteArrayDeleter.h"
 #include "crypto-suites/crypto-curve/openssl_curve_wrapper.h"
 #include "crypto-suites/common/custom_assert.h"


### PR DESCRIPTION
I include `#include <memory>` to `openssl_curve_wrapper.cpp` because my system needed it in order to compile this library. After doing some research, it appears that this is necessary for newer versions of C++.